### PR TITLE
e2e: Disable busybox bootstrap due to frequent dl failures, from sylabs 313

### DIFF
--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -61,12 +61,13 @@ func (c imgBuildTests) buildFrom(t *testing.T) {
 		buildSpec   string
 		requireArch string
 	}{
-		{
-			name:      "BusyBox",
-			buildSpec: "../examples/busybox/Singularity",
-			// TODO: example has arch hard coded in download URL
-			requireArch: "amd64",
-		},
+		// Disabled due to frequent download failures of the busybox tgz
+		// {
+		// 	name:      "BusyBox",
+		// 	buildSpec: "../examples/busybox/Singularity",
+		// 	// TODO: example has arch hard coded in download URL
+		// 	requireArch: "amd64",
+		// },
 		{
 			name:       "Debootstrap",
 			dependency: "debootstrap",

--- a/internal/pkg/build/sources/conveyorPacker_busybox_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_busybox_test.go
@@ -21,6 +21,9 @@ import (
 const busyBoxDef = "../../../../examples/busybox/Singularity"
 
 func TestBusyBoxConveyor(t *testing.T) {
+	// 2021-09-07 - Always skip due to frequent download failures
+	t.SkipNow()
+
 	if testing.Short() {
 		t.SkipNow()
 	}


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#313

The original PR description was:

> Disable busybox bootstrap from tgz, as the download from the busybox site has been failing often, disrupting CI / merges.