### PR TITLE
Bump Go to 1.17.2, from sylabs 363

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   check_go_mod:
     name: check_go_mod
     runs-on: ubuntu-20.04
-    container: golang:1.17.1
+    container: golang:1.17.2
     steps:
       - uses: actions/checkout@v2
 
@@ -46,7 +46,7 @@ jobs:
   debian:
     name: debian
     runs-on: ubuntu-20.04
-    container: golang:1.17.1-buster
+    container: golang:1.17.2-buster
     steps:
       - name: Fetch deps
         run: |
@@ -62,7 +62,7 @@ jobs:
   alpine:
     name: alpine
     runs-on: ubuntu-20.04
-    container: golang:1.17.1-alpine
+    container: golang:1.17.2-alpine
     steps:
       - name: Fetch deps
         run: apk add -q --no-cache git alpine-sdk automake libtool linux-headers libarchive-dev util-linux-dev libuuid openssl-dev gawk sed cryptsetup
@@ -123,7 +123,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.1
+          go-version: 1.17.2
 
       - name: Fetch deps
         run: sudo apt-get install -y build-essential squashfs-tools libseccomp-dev cryptsetup
@@ -145,7 +145,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.1
+          go-version: 1.17.2
 
       - name: Fetch deps
         run: sudo apt-get install -y build-essential squashfs-tools libseccomp-dev cryptsetup
@@ -189,7 +189,7 @@ jobs:
         if: env.run_tests
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.1
+          go-version: 1.17.2
 
       - name: Fetch deps
         if: env.run_tests
@@ -224,7 +224,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.1
+          go-version: 1.17.2
 
       - name: Check pkg/... doesn't depend on buildcfg
         run: |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -55,7 +55,7 @@ _**NOTE:** if you are updating Go from a older version, make sure you remove
 `/usr/local/go` before reinstalling it._
 
 ```sh
-export VERSION=1.17.1 OS=linux ARCH=amd64  # change this as you need
+export VERSION=1.17.2 OS=linux ARCH=amd64  # change this as you need
 
 wget -O /tmp/go${GOVERSION}.${OS}-${ARCH}.tar.gz \
   https://dl.google.com/go/go${GOVERSION}.${OS}-${ARCH}.tar.gz


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#363

The original PR description was:

> Bump `go` version to 1.17.2 in CI config and installation documentation.