### PR TITLE
feat: support for multi-part concurrent library image download, e2e: linearize config --set --reset for concurrent pull tests, omit progress bar on redirected output, from sylabs 395, 403, 415

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@
   and it requires being used in combination with `--writable` in user
   namespace mode.
   Please see documentation for more details.
+- Perform concurrent multi-part downloads for `library://` URIs. Uses 3
+  concurrent downloads by default, and is configurable in `singularity.conf` or
+  via environment variables.
 
 ### Changed defaults / behaviours
 

--- a/e2e/pull/concurrency.go
+++ b/e2e/pull/concurrency.go
@@ -1,0 +1,170 @@
+// Copyright (c) 2021, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package pull
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/hpcng/singularity/e2e/internal/e2e"
+)
+
+func (c ctx) testDownloadConcurrencyConfig(t *testing.T) {
+	tests := []struct {
+		name             string
+		setting          string
+		value            string
+		expectedExitCode int
+	}{
+		{"DownloadConcurrency", "download concurrency", "5", 0},
+		{"InvalidDownloadConcurrency", "download concurrency", "-1", 255},
+		{"DownloadPartSize", "download part size", "32768", 0},
+		{"InvalidDownloadPartSize", "download part size", "-1", 255},
+		{"DownloadBufferSize", "download buffer size", "65536", 0},
+		{"InvalidDownloadBufferSize", "download buffer size", "-1", 255},
+	}
+
+	for _, tt := range tests {
+		defer func(t *testing.T) {
+			c.env.RunSingularity(
+				t,
+				e2e.WithProfile(e2e.RootProfile),
+				e2e.WithCommand("config global"),
+				e2e.WithArgs("--reset", tt.setting),
+				e2e.ExpectExit(0),
+			)
+		}(t)
+
+		c.env.RunSingularity(
+			t,
+			e2e.WithProfile(e2e.RootProfile),
+			e2e.WithCommand("config global"),
+			e2e.WithArgs("--set", tt.setting, tt.value),
+			e2e.ExpectExit(tt.expectedExitCode),
+		)
+	}
+}
+
+func (c ctx) testDownloadConcurrency(t *testing.T) {
+	c.testDownloadConcurrencyConfig(t)
+	c.testDownloads(t)
+}
+
+func (c ctx) testDownloads(t *testing.T) {
+	const srcURI = "library://alpine:3.11.5"
+
+	tests := []struct {
+		name             string
+		settings         map[string]string
+		envVars          []string
+		expectedExitCode int
+	}{
+		// test traditional sequential download
+		{"Concurrency1Cfg", map[string]string{"download concurrency": "1"}, nil, 0},
+		// test concurrency 3
+		{"Concurrency3Cfg", map[string]string{"download concurrency": "3"}, nil, 0},
+		// test concurrency 10
+		{"Concurrency10Cfg", map[string]string{"download concurrency": "10"}, nil, 0},
+
+		// test 1/3/10 goroutines (set via env vars)
+		{"Concurrency1Env", nil, []string{"SINGULARITY_DOWNLOAD_CONCURRENCY=1"}, 0},
+		{"Concurrency3Env", nil, []string{"SINGULARITY_DOWNLOAD_CONCURRENCY=3"}, 0},
+		{"Concurrency10Env", nil, []string{"SINGULARITY_DOWNLOAD_CONCURRENCY=10"}, 0},
+
+		// test concurrent download with 1 MiB and 8 MiB part size
+		{"PartSize1MCfg", map[string]string{"download part size": "1048576"}, nil, 0},
+		{"PartSize8MCfg", map[string]string{"download part size": "8388608"}, nil, 0},
+
+		// test concurrent download with 1 MiB and 8 MiB part size (via env vars)
+		{"PartSize1MEnv", nil, []string{"SINGULARITY_DOWNLOAD_PART_SIZE=1048576"}, 0},
+		{"PartSize8MEnv", nil, []string{"SINGULARITY_DOWNLOAD_PART_SIZE=8388608"}, 0},
+
+		// use 8 byte and 64 KiB buffer size for concurrent downloads
+		{"BufferSize1Cfg", map[string]string{"download buffer size": "8"}, nil, 0},
+		{"BufferSize65536Cfg", map[string]string{"download buffer size": "65536"}, nil, 0},
+
+		// use 8 byte and 64 KiB buffer size for concurrent downloads (via env vars)
+		{"BufferSize1Env", nil, []string{"SINGULARITY_DOWNLOAD_BUFFER_SIZE=8"}, 0},
+		{"BufferSize65536Env", nil, []string{"SINGULARITY_DOWNLOAD_BUFFER_SIZE=65536"}, 0},
+
+		// multiple settings (concurrency 1, download buffer size 64 KiB)
+		{"MultipleSettings", map[string]string{"download concurrency": "1", "download buffer size": "65536"}, nil, 0},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		tmpdir, err := ioutil.TempDir(c.env.TestDir, "pull_test.")
+		if err != nil {
+			t.Fatalf("Failed to create temporary directory for pull test: %+v", err)
+		}
+		defer os.RemoveAll(tmpdir)
+
+		cleanCfg := []string{}
+
+		if tt.settings != nil {
+			cfgCmdOps := []e2e.SingularityCmdOp{
+				e2e.WithProfile(e2e.RootProfile),
+				e2e.WithCommand("config global"),
+				e2e.ExpectExit(0),
+			}
+
+			for key, value := range tt.settings {
+				cfgCmd := append(cfgCmdOps, e2e.WithArgs("--set", key, value))
+
+				c.env.RunSingularity(t, cfgCmd...)
+
+				cleanCfg = append(cleanCfg, key)
+			}
+		}
+
+		ts := testStruct{
+			desc:             tt.name,
+			srcURI:           srcURI,
+			expectedExitCode: tt.expectedExitCode,
+			expectedImage:    getImageNameFromURI(srcURI),
+			envVars:          tt.envVars,
+		}
+
+		// reset config set via tests
+		defer func(t *testing.T) {
+			for _, cfg := range cleanCfg {
+				c.env.RunSingularity(
+					t,
+					e2e.WithProfile(e2e.RootProfile),
+					e2e.WithCommand("config global"),
+					e2e.WithArgs("--reset", cfg),
+					e2e.ExpectExit(0),
+				)
+			}
+		}(t)
+
+		// Since we are not passing an image name, change the current
+		// working directory to the temporary directory we just created so
+		// that we know it's clean. We don't do this for the other case in
+		// order to catch spurious files showing up. Maybe later we can
+		// examine the directory and assert that it only contains what we
+		// expect.
+		oldwd, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("Failed to get working directory for pull test: %+v", err)
+		}
+		defer os.Chdir(oldwd)
+
+		os.Chdir(tmpdir)
+
+		// if there's a pullDir, that's where we expect to find the image
+		if ts.pullDir != "" {
+			os.Chdir(ts.pullDir)
+		}
+
+		ts.expectedImage = getImageNameFromURI(srcURI)
+
+		// pull image
+		c.imagePull(t, ts)
+	}
+}

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -652,7 +652,8 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 
 			t.Run("pull", c.testPullCmd)
 			t.Run("pullDisableCache", c.testPullDisableCacheCmd)
-			t.Run("downloadConcurrency", c.testDownloadConcurrency)
+			t.Run("concurrencyConfig", c.testConcurrencyConfig)
+			t.Run("concurrentPulls", c.testConcurrentPulls)
 
 			// Regressions
 			t.Run("issue5808", c.issue5808)

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -44,6 +44,7 @@ type testStruct struct {
 	pullDir          string
 	imagePath        string
 	expectedImage    string
+	envVars          []string
 }
 
 var tests = []testStruct{
@@ -250,6 +251,7 @@ func (c *ctx) imagePull(t *testing.T, tt testStruct) {
 		t,
 		e2e.AsSubtest(tt.desc),
 		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithEnv(tt.envVars),
 		e2e.WithCommand("pull"),
 		e2e.WithArgs(strings.Split(argv, " ")...),
 		e2e.ExpectExit(tt.expectedExitCode))
@@ -650,6 +652,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 
 			t.Run("pull", c.testPullCmd)
 			t.Run("pullDisableCache", c.testPullDisableCacheCmd)
+			t.Run("downloadConcurrency", c.testDownloadConcurrency)
 
 			// Regressions
 			t.Run("issue5808", c.issue5808)

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/yvasiyarov/newrelic_platform_go v0.0.0-20160601141957-9c099fbc30e9 // indirect
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
 	golang.org/x/sys v0.0.0-20210925032602-92d5a993a665
+	golang.org/x/term v0.0.0-20210916214954-140adaaadfaf
 	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools/v3 v3.0.3
 	mvdan.cc/sh/v3 v3.4.1-0.20211012151248-7e067a88c992

--- a/go.mod
+++ b/go.mod
@@ -37,8 +37,8 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/sylabs/json-resp v0.8.0
 	github.com/sylabs/scs-build-client v0.2.1
-	github.com/sylabs/scs-key-client v0.6.2
-	github.com/sylabs/scs-library-client v1.0.5
+	github.com/sylabs/scs-key-client v0.7.1
+	github.com/sylabs/scs-library-client v1.2.0
 	github.com/vbauerster/mpb/v4 v4.12.2
 	github.com/vbauerster/mpb/v6 v6.0.4
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect

--- a/go.sum
+++ b/go.sum
@@ -885,7 +885,6 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/sylabs/json-resp v0.7.1/go.mod h1:3O9ze5PoYxia6106m5x+5G5ohnW1AJX/FURjCNovtzA=
 github.com/sylabs/json-resp v0.8.0 h1:bZ932uaF220aPqT0+x/vakoaGCGNbpLCjUFm1f+JKlY=
 github.com/sylabs/json-resp v0.8.0/go.mod h1:bUGV9cqShOyxz7RxBq03Yt9raKGfELKrfN6Yac3lfiw=
 github.com/sylabs/scs-build-client v0.2.1 h1:/Hk9SI+hNPPjuacNk0aFvi6u7tFdNVtPzz+ZdO3NMQc=

--- a/go.sum
+++ b/go.sum
@@ -890,10 +890,10 @@ github.com/sylabs/json-resp v0.8.0 h1:bZ932uaF220aPqT0+x/vakoaGCGNbpLCjUFm1f+JKl
 github.com/sylabs/json-resp v0.8.0/go.mod h1:bUGV9cqShOyxz7RxBq03Yt9raKGfELKrfN6Yac3lfiw=
 github.com/sylabs/scs-build-client v0.2.1 h1:/Hk9SI+hNPPjuacNk0aFvi6u7tFdNVtPzz+ZdO3NMQc=
 github.com/sylabs/scs-build-client v0.2.1/go.mod h1:/kuKpMv3JnFd2IXCmX1+OCYxBxv+zUUWv92Az3QvwfE=
-github.com/sylabs/scs-key-client v0.6.2 h1:PTdmkE50rFMrSty9usl8wnzaW+JPK0rjXF4cdIQ3MEo=
-github.com/sylabs/scs-key-client v0.6.2/go.mod h1:WoTk47nNRrk0uLfblxUFekxDIIVPY4l2/9evME5fgX0=
-github.com/sylabs/scs-library-client v1.0.5 h1:u8ueCIQaa38/B0axtKUzdWSQ6uLXL9HvLQGNkB69Oe0=
-github.com/sylabs/scs-library-client v1.0.5/go.mod h1:ufza0uq4ohT7Fk2Y7vm+uRyMm7gRA+Fde1nxyhGfhTk=
+github.com/sylabs/scs-key-client v0.7.1 h1:m8w1fK5Ja/ahdgDRiAaFJ8CMOIOm8m37gKgSCwOgoeY=
+github.com/sylabs/scs-key-client v0.7.1/go.mod h1:/5RJxsW7iIKDD9FU2qfGvlCs+MfjigV7InUDE1SIR30=
+github.com/sylabs/scs-library-client v1.2.0 h1:Ee9fsnYy15pF1Y1RF/9gBUA7Up4XuEbOPPMPHMJr+zM=
+github.com/sylabs/scs-library-client v1.2.0/go.mod h1:WddtCtL42AAsmCiUe8oxjHKbER5vbXtaO7Cxlmf+n0c=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=

--- a/internal/app/singularity/push.go
+++ b/internal/app/singularity/push.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/hpcng/sif/pkg/sif"
 	"github.com/hpcng/singularity/internal/pkg/util/fs"
@@ -21,6 +22,7 @@ import (
 	"github.com/sylabs/scs-library-client/client"
 	"github.com/vbauerster/mpb/v4"
 	"github.com/vbauerster/mpb/v4/decor"
+	"golang.org/x/term"
 )
 
 // ErrLibraryUnsigned indicated that the image intended to be used is
@@ -79,8 +81,12 @@ func (c *progressCallback) Finish() {
 // LibraryPush will upload an image file according to the provided LibraryPushSpec
 // Before uploading, the image will be checked for a valid signature unless AllowUnsigned is true
 func LibraryPush(ctx context.Context, pushSpec LibraryPushSpec, libraryConfig *client.Config, co []keyclient.Option) error {
-	if _, err := os.Stat(pushSpec.SourceFile); os.IsNotExist(err) {
-		return fmt.Errorf("unable to open: %v: %v", pushSpec.SourceFile, err)
+	fi, err := os.Stat(pushSpec.SourceFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("unable to open: %v: %v", pushSpec.SourceFile, err)
+		}
+		return err
 	}
 
 	arch, err := sifArch(pushSpec.SourceFile)
@@ -116,8 +122,22 @@ func LibraryPush(ctx context.Context, pushSpec LibraryPushSpec, libraryConfig *c
 	}
 	defer f.Close()
 
-	resp, err := libraryClient.UploadImage(ctx, f, r.Host+r.Path, arch, r.Tags, pushSpec.Description, &progressCallback{})
-	if err != nil {
+	var progressBar client.UploadCallback
+	if !term.IsTerminal(2) {
+		sylog.Infof("Uploading %d bytes\n", fi.Size())
+	} else {
+		progressBar = &progressCallback{}
+	}
+
+	var resp *client.UploadImageComplete
+
+	defer func(t time.Time) {
+		if err == nil && resp != nil && progressBar == nil {
+			sylog.Infof("Uploaded %d bytes in %v\n", fi.Size(), time.Since(t))
+		}
+	}(time.Now())
+
+	if resp, err = libraryClient.UploadImage(ctx, f, r.Host+r.Path, arch, r.Tags, pushSpec.Description, progressBar); err != nil {
 		return err
 	}
 

--- a/internal/pkg/client/library/pull.go
+++ b/internal/pkg/client/library/pull.go
@@ -26,8 +26,6 @@ var ErrLibraryPullUnsigned = errors.New("failed to verify container")
 
 // pull will pull a library image into the cache if directTo="", or a specific file if directTo is set.
 func pull(ctx context.Context, imgCache *cache.Handle, directTo string, imageRef *libclient.Ref, arch string, libraryConfig *libclient.Config) (imagePath string, err error) {
-	sylog.GetLevel()
-
 	c, err := libclient.NewClient(libraryConfig)
 	if err != nil {
 		return "", fmt.Errorf("unable to initialize client library: %v", err)
@@ -45,7 +43,7 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo string, imageRef
 
 	if directTo != "" {
 		sylog.Infof("Downloading library image")
-		if err = DownloadImage(ctx, c, directTo, arch, imageRef, client.ProgressBarCallback(ctx)); err != nil {
+		if err = DownloadImage(ctx, c, directTo, arch, imageRef, &client.DownloadProgressBar{}); err != nil {
 			return "", fmt.Errorf("unable to download image: %v", err)
 		}
 		imagePath = directTo
@@ -59,7 +57,7 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo string, imageRef
 		if !cacheEntry.Exists {
 			sylog.Infof("Downloading library image")
 
-			if err := DownloadImage(ctx, c, cacheEntry.TmpPath, arch, imageRef, client.ProgressBarCallback(ctx)); err != nil {
+			if err := DownloadImage(ctx, c, cacheEntry.TmpPath, arch, imageRef, &client.DownloadProgressBar{}); err != nil {
 				return "", fmt.Errorf("unable to download image: %v", err)
 			}
 

--- a/pkg/util/singularityconf/config.go
+++ b/pkg/util/singularityconf/config.go
@@ -69,7 +69,7 @@ type File struct {
 	NvidiaContainerCliPath  string   `directive:"nvidia-container-cli path"`
 	UnsquashfsPath          string   `directive:"unsquashfs path"`
 	ImageDriver             string   `directive:"image driver"`
-	DownloadConcurrency     uint     `default:"1" directive:"download concurrency"`
+	DownloadConcurrency     uint     `default:"3" directive:"download concurrency"`
 	DownloadPartSize        uint     `default:"5242880" directive:"download part size"`
 	DownloadBufferSize      uint     `default:"32768" directive:"download buffer size"`
 }
@@ -439,20 +439,20 @@ shared loop devices = {{ if eq .SharedLoopDevices true }}yes{{ else }}no{{ end }
 image driver = {{ .ImageDriver }}
 
 # DOWNLOAD CONCURRENCY: [UINT]
-# DEFAULT: 1
+# DEFAULT: 3
 # This option specifies how many concurrent streams when downloading (pulling)
 # an image from cloud library.
-# download concurrency = {{ .DownloadConcurrency }}
+download concurrency = {{ .DownloadConcurrency }}
 
 # DOWNLOAD PART SIZE: [UINT]
 # DEFAULT: 5242880
 # This option specifies the size of each part when concurrent downloads are
 # enabled.
-# download part size = {{ .DownloadPartSize }}
+download part size = {{ .DownloadPartSize }}
 
 # DOWNLOAD BUFFER SIZE: [UINT]
 # DEFAULT: 32768
 # This option specifies the transfer buffer size when concurrent downloads
 # are enabled.
-# download buffer size = {{ .DownloadBufferSize }}
+download buffer size = {{ .DownloadBufferSize }}
 `

--- a/pkg/util/singularityconf/config.go
+++ b/pkg/util/singularityconf/config.go
@@ -69,6 +69,9 @@ type File struct {
 	NvidiaContainerCliPath  string   `directive:"nvidia-container-cli path"`
 	UnsquashfsPath          string   `directive:"unsquashfs path"`
 	ImageDriver             string   `directive:"image driver"`
+	DownloadConcurrency     uint     `default:"1" directive:"download concurrency"`
+	DownloadPartSize        uint     `default:"5242880" directive:"download part size"`
+	DownloadBufferSize      uint     `default:"32768" directive:"download buffer size"`
 }
 
 const TemplateAsset = `# SINGULARITY.CONF
@@ -434,4 +437,22 @@ shared loop devices = {{ if eq .SharedLoopDevices true }}yes{{ else }}no{{ end }
 # If the driver name specified has not been registered via a plugin installation
 # the run-time will abort.
 image driver = {{ .ImageDriver }}
+
+# DOWNLOAD CONCURRENCY: [UINT]
+# DEFAULT: 1
+# This option specifies how many concurrent streams when downloading (pulling)
+# an image from cloud library.
+# download concurrency = {{ .DownloadConcurrency }}
+
+# DOWNLOAD PART SIZE: [UINT]
+# DEFAULT: 5242880
+# This option specifies the size of each part when concurrent downloads are
+# enabled.
+# download part size = {{ .DownloadPartSize }}
+
+# DOWNLOAD BUFFER SIZE: [UINT]
+# DEFAULT: 32768
+# This option specifies the transfer buffer size when concurrent downloads
+# are enabled.
+# download buffer size = {{ .DownloadBufferSize }}
 `

--- a/pkg/util/singularityconf/parser_test.go
+++ b/pkg/util/singularityconf/parser_test.go
@@ -119,6 +119,10 @@ func TestGetConfig(t *testing.T) {
 	directives["max loop devices"] = []string{"42"}
 	directives["bind path"] = []string{"/etc/hosts"}
 
+	directives["download concurrency"] = []string{"42"}
+	directives["download part size"] = []string{"1234"}
+	directives["download buffer size"] = []string{"4567"}
+
 	config, err := GetConfig(directives)
 	if err != nil {
 		t.Errorf("unexpected error while getting config: %s", err)
@@ -134,6 +138,15 @@ func TestGetConfig(t *testing.T) {
 	}
 	if !reflect.DeepEqual(config.BindPath, directives["bind path"]) {
 		t.Errorf("bad value for BindPath: %v", config.BindPath)
+	}
+	if config.DownloadConcurrency != 42 {
+		t.Errorf("bad value for DownloadConcurrency: %v", config.DownloadConcurrency)
+	}
+	if config.DownloadPartSize != 1234 {
+		t.Errorf("bad value for DownloadPartSize: %v", config.DownloadPartSize)
+	}
+	if config.DownloadBufferSize != 4567 {
+		t.Errorf("bad value for DownloadBufferSize: %v", config.DownloadPartSize)
 	}
 }
 


### PR DESCRIPTION
This pulls in sylabs PRs

- sylabs/singularity#395
- sylabs/singularity#403
- sylabs/singularity#415
 which fixed
- sylabs/singularity#394
- sylabs/singularity#414

The original PR descriptions were:

> _Work performed by @EmmEff - I've just cherry picked / squashed off his branch_
> 
> Adds singularity.conf and env var overrides:
> 
> `SINGULARITY_DOWNLOAD_CONCURRENCY` - number of concurrent requests for
> multi-part download (default: 1)
> 
> `SINGULARITY_DOWNLOAD_PART_SIZE` - size (in bytes) of part for
> multi-part download (default: 5242880)
> 
> `SINGULARITY_DOWNLOAD_BUFFER_SIZE` - size (in bytes) of xfer buffer
> used to download part (default: 32768)

> We can't accumulate config resets with defer as we need to run each test from a 'clean' starting config, and a defer is scoped to the function, not the loop iteration.
> 
> Apologies - this wasn't caught when I reviewed the concurrency PR.

> Do not display progress bar when pull/push output is redirected