### PR TITLE
e2e: check more output of plugin commands, from sylabs 449

### DIFF
--- a/e2e/plugin/plugin.go
+++ b/e2e/plugin/plugin.go
@@ -44,6 +44,14 @@ func (c ctx) testPluginBasic(t *testing.T) {
 			expectExit: 0,
 		},
 		{
+			name:       "ListNoPlugins",
+			profile:    e2e.UserProfile,
+			command:    "plugin list",
+			args:       []string{},
+			expectExit: 0,
+			expectOp:   e2e.ExpectOutput(e2e.ExactMatch, "There are no plugins installed."),
+		},
+		{
 			name:       "Compile",
 			profile:    e2e.UserProfile,
 			command:    "plugin compile",
@@ -65,12 +73,12 @@ func (c ctx) testPluginBasic(t *testing.T) {
 			expectExit: 255,
 		},
 		{
-			name:       "List",
+			name:       "ListAfterInstall",
 			profile:    e2e.UserProfile,
 			command:    "plugin list",
 			args:       []string{},
 			expectExit: 0,
-			expectOp:   e2e.ExpectOutput(e2e.ContainMatch, pluginName),
+			expectOp:   e2e.ExpectOutput(e2e.ContainMatch, "yes  "+pluginName),
 		},
 		{
 			name:       "Disable",
@@ -78,6 +86,14 @@ func (c ctx) testPluginBasic(t *testing.T) {
 			command:    "plugin disable",
 			args:       []string{pluginName},
 			expectExit: 0,
+		},
+		{
+			name:       "ListAfterDisable",
+			profile:    e2e.UserProfile,
+			command:    "plugin list",
+			args:       []string{},
+			expectExit: 0,
+			expectOp:   e2e.ExpectOutput(e2e.ContainMatch, "no  "+pluginName),
 		},
 		{
 			name:       "DisableAsUser",
@@ -92,6 +108,14 @@ func (c ctx) testPluginBasic(t *testing.T) {
 			command:    "plugin enable",
 			args:       []string{pluginName},
 			expectExit: 0,
+		},
+		{
+			name:       "ListAfterEnable",
+			profile:    e2e.UserProfile,
+			command:    "plugin list",
+			args:       []string{},
+			expectExit: 0,
+			expectOp:   e2e.ExpectOutput(e2e.ContainMatch, "yes  "+pluginName),
 		},
 		{
 			name:       "EnableAsUser",
@@ -113,6 +137,7 @@ func (c ctx) testPluginBasic(t *testing.T) {
 			command:    "plugin inspect",
 			args:       []string{sifFile},
 			expectExit: 0,
+			expectOp:   e2e.ExpectOutput(e2e.ContainMatch, "Name: "+pluginName),
 		},
 		{
 			name:       "UninstallAsUser",
@@ -127,6 +152,14 @@ func (c ctx) testPluginBasic(t *testing.T) {
 			command:    "plugin uninstall",
 			args:       []string{pluginName},
 			expectExit: 0,
+		},
+		{
+			name:       "ListAfterUninstall",
+			profile:    e2e.UserProfile,
+			command:    "plugin list",
+			args:       []string{},
+			expectExit: 0,
+			expectOp:   e2e.ExpectOutput(e2e.ExactMatch, "There are no plugins installed."),
 		},
 	}
 


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#449
 which fixed
- sylabs/singularity#448

The original PR description was:

> Check output of plugin commands in addition to return code. Check state reported by plugin list across install/disable/enable/uninstall.